### PR TITLE
Fix order of glShader arguments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,8 @@ var glShader = require('gl-shader')
 var glslify  = require('glslify')
 
 var shader = glShader(gl,
-  glslify('./shader.frag'),
-  glslify('./shader.vert')
+  glslify('./shader.vert'),
+  glslify('./shader.frag')
 )
 ```
 


### PR DESCRIPTION
Error compiling shader unless you pass the vertex shader before the fragment shader in the arguments list.