### PR TITLE
Added relative path to `./browser.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webgl"
   ],
   "browser": {
-    "index.js": "browser.js"
+    "index.js": "./browser.js"
   },
   "homepage": "https://github.com/stackgl/glslify",
   "bugs": {


### PR DESCRIPTION
I ran into an issue (and so has this guy https://github.com/stackgl/glslify-loader/issues/5) where webpack can't resolve glslify - specifically, it couldn't resolve `browser.js`. By just adding relative pathing to `./browser.js`, it knows to look relative to the module (instead of in the root `node_modules` and can find the file.