### PR TITLE
Add a section about fixing references

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ float accumulate(float list[N]) {
 }
 #pragma glslify: export(accumulate)
 ```
-But looking closely, we've noticed that this module doesn't actually supply the integer `N` or the function `map`.  We have to make sure they are already defined when we require the module, and pass their names along with the `require` function:
+But notice that this module doesn't actually declare `const int N;` or define a function `map` anywhere.  We have to make sure they are already defined when we require the module, and pass their names along with the `require` function:
 
 ``` glsl
 const int M = 500;

--- a/README.md
+++ b/README.md
@@ -302,6 +302,50 @@ struct Light {
 #pragma glslify: export(Light)
 ```
 
+### Passing references between modules
+Normally, glslify renames tokens to avoid conflicts across contexts.  Sometimes, however, you want to reference the same thing from different contexts.  The `require` function lets you explicitly fix reference names in order to guarantee that two different modules are talking about the same reference.
+
+Give `some-module` access to locally declared `bar` whenever it looks for `foo` internally:
+``` glsl
+int bar;
+#pragma require('some-module',foo=bar,...)
+```
+It's important to make sure that `bar` has already been declared when you invoke `#pragma require(...)`.
+
+Now time for some imagination.  Let's pretend that we have some `float[500]` arrays that we'd like to be summed up.
+
+Here's a module that performs a reduction using a function `map`.
+``` glsl
+float accumulate(float list[N]) {
+  float z = 0;
+  for (int i = 0; i<N; i++) {
+    z = map(z,list[i]);
+  }
+  return z;
+}
+#pragma glslify: export(accumulate)
+```
+But looking closely, we've noticed that this module doesn't actually supply the integer `N` or the function `map`.  We have to make sure they are already defined when we require the module, and pass their names along with the `require` function:
+
+``` glsl
+const int M = 500;
+float add(float a, float b){ return a+b; }
+
+#pragma sum500 = require('./accumulator.glsl',N=M,map=add)
+```
+The accumulator has been imported and glslified into a `sum` function.  We can also multiply all of the floats in some `float[17]` arrays the same way:
+``` glsl
+const int M = 500;
+const int L = 17;
+float add(float a, float b){ return a+b; }
+float mul(float a, float b){ return a*b; }
+
+#pragma sum500 = require('./accumulator.glsl',N=M,map=add)
+#pragma product17 = require('./accumulator.glsl',N=L,map=mul)
+```
+
+[Glsl-hash-blur](http://stack.gl/packages/#stackgl/glsl-hash-blur) is an example of a module that uses this feature.
+
 ## Source Transforms
 
 Source transforms are a feature inspired by browserify, allowing you to


### PR DESCRIPTION
I was very confused about where the `require('module',foo=bar)` syntax was coming from, and how to use it in my own modules.  mikolalysenko from #stackgl on freenode explained this to me in a conversation:
```
<micahf> when modules use the require(glsl-module,foo=bar) syntax, is that something built into glslify?
<micahf> i don't see that in the documentation, only in examples
<micahf> is it to make sure when the variable and function names get mogrified, that relationships between modules are preserved?
<mikolalysenko> micahf: that's right
<mikolalysenko> basically glslify pastes the code from the module into your project at that point, and renames all the free variables within that module
<micahf> mikolalysenko, okay, this stuff should be in the documentation!
<mikolalysenko> yeah, it should
<micahf> mikolalysenko, so just to clarify, if I use "foo=bar", it will pass bar from the local code into glsl-module as foo
<mikolalysenko> yes
<mikolalysenko> so the free variable foo in the module will be replaced with bar
<micahf> mikolalysenko, that makes sense.  are there any other tricks of the require(...) function?  can i pass in other options?
<mikolalysenko> nope, that is it
<micahf> mikolalysenko, pretty straightforward!
<mikolalysenko> the main reason for this feature is that it lets you emulate things like closures/first class functions
<mikolalysenko> for example if you want to write a raytracer, you can reuse your ray marching loop
<mikolalysenko> by having whatever implicit you are tracing go as an input into the ray marcher
<micahf> mikolalysenko, does glslify take care of the order of code?  or do I need to make sure bar is defined before the point when I do require(glsl-module,foo=bar) ?
<mikolalysenko> you need to make sure bar is declared before you import the module
<mikolalysenko> since it pastes the module in your code at that point
```