### PR TITLE
allow glsify(path.join(

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ function transform(jsFilename, browserifyOpts) {
       require: {
         resolve: nodeResolve
       }
-    }
+    },
+    varModules: { path: path }
   })
 
   return sm


### PR DESCRIPTION
```
glsify(path.join(__dirname, 'shader.frag'))
```

fails at the moment

I added `path` to `staticModule` like [brfs] does it.

[brfs]:https://github.com/substack/brfs