### PR TITLE
emit file and error events in the transform

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -208,6 +208,8 @@ module.exports = function (file, opts) {
 
   function createDeps (opts) {
     var depper = gdeps(opts)
+    depper.on('error', function (err) { d.emit('error', err) })
+    depper.on('file', function (file) { d.emit('file', file) })
     var transforms = opts.transform || []
     transforms = Array.isArray(transforms) ? transforms : [transforms]
     transforms.forEach(function(transform) {


### PR DESCRIPTION
glslify-deps emits error and file events, which were not going anywhere before. With this patch, they are emitted on the transform stream object which browserify/watchify can use to make error reports without crashing. Watchify will also look at `file` events to know when it should invalidate its cache for the originating file.

Fixes https://github.com/stackgl/glslify/issues/83